### PR TITLE
Add support for GetObjects and Query commands and results, add DroolsTypeAttribute and InsertType methods

### DIFF
--- a/KieServerAdapter.Test/KieServerAdapter.Test.csproj
+++ b/KieServerAdapter.Test/KieServerAdapter.Test.csproj
@@ -44,6 +44,9 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.1.17\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/KieServerAdapter.Test/app.config
+++ b/KieServerAdapter.Test/app.config
@@ -20,7 +20,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/KieServerAdapter.Test/packages.config
+++ b/KieServerAdapter.Test/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.1.17" targetFramework="net452" />
   <package id="MSTest.TestFramework" version="1.1.17" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
 </packages>

--- a/KieServerAdapter/CommandGetObjects.cs
+++ b/KieServerAdapter/CommandGetObjects.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+
+namespace KieServerAdapter
+{
+    /// <summary>
+    /// Get all objects in drools memory
+    /// </summary>
+    /// <remarks>
+    /// Note Kie server doesn't appear to implement the object-filter over REST,
+    /// so it has been removed from this class.  Use CommandQuery instead and define
+    /// a query in Drools to return the objects you want.
+    /// </remarks>
+    public class CommandGetObjects : ICommand, ICommandOutIdentifier
+    {
+        public const string OutIdentifierDefault = "getObjectsResults";
+
+        [JsonProperty("out-identifier")]
+        public string OutIdentifier { get; set; } = OutIdentifierDefault;
+
+        [JsonIgnore]
+        public KieCommandTypeEnum CommandType { get; } = KieCommandTypeEnum.GetObjects;
+    }
+}

--- a/KieServerAdapter/CommandInsert.cs
+++ b/KieServerAdapter/CommandInsert.cs
@@ -10,6 +10,9 @@ namespace KieServerAdapter
         [JsonProperty("object")]
         public CommandObject CommandObject { get; set; }
 
+        [JsonProperty("return-object")]
+        public bool ReturnObject { get; set; } = true;
+
         [JsonIgnore]
         public KieCommandTypeEnum CommandType { get; } = KieCommandTypeEnum.Insert;
     }

--- a/KieServerAdapter/CommandObjectSerializer.cs
+++ b/KieServerAdapter/CommandObjectSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace KieServerAdapter
@@ -24,7 +25,13 @@ namespace KieServerAdapter
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            JToken token = JToken.Load(reader);
+            if (token.Type == JTokenType.Object)
+            {
+                var prop = token.First as JProperty;
+                return new CommandObject((prop as JProperty).Value, (prop as JProperty).Name);
+            }
+            return null;
         }
 
         public override bool CanConvert(Type objectType)

--- a/KieServerAdapter/CommandQuery.cs
+++ b/KieServerAdapter/CommandQuery.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace KieServerAdapter
+{
+    public class CommandQuery : ICommand, ICommandOutIdentifier
+    {
+        public const string OutIdentifierDefault = "queryResults";
+
+        [JsonProperty("out-identifier")]
+        public string OutIdentifier { get; set; } = OutIdentifierDefault;
+
+        [JsonProperty("arguments")]
+        public IEnumerable<object> Arguments { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; } 
+
+        [JsonIgnore]
+        public KieCommandTypeEnum CommandType { get; } = KieCommandTypeEnum.Query;
+    }
+}

--- a/KieServerAdapter/DroolsTypeAttribute.cs
+++ b/KieServerAdapter/DroolsTypeAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace KieServerAdapter
+{
+    /// <summary>
+    /// Attribute to specify an explicit Drools (Java) fully qualified type name
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class |
+                    AttributeTargets.Struct)
+]
+    public class DroolsTypeAttribute : Attribute
+    {
+        public string TypeName { get; set; }
+
+        public DroolsTypeAttribute(string name)
+        {
+            TypeName = name;
+        }
+    }
+}

--- a/KieServerAdapter/ExecutionResult.cs
+++ b/KieServerAdapter/ExecutionResult.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace KieServerAdapter
 {
@@ -6,5 +10,115 @@ namespace KieServerAdapter
     {
         public List<KeyValuePair<string, object>> Results;
         public List<KeyValuePair<string, object>> Facts;
+
+        /// <summary>
+        /// indexer for the Results collection
+        /// </summary>
+        public object this[string resultKey]
+        {
+            get { return Results.SingleOrDefault(e => e.Key.Equals(resultKey)).Value; }
+        }
+
+        /// <summary>
+        /// retrieve the object collection resulting from a GetObjects command
+        /// </summary>
+        /// <param name="outIdentifier">the out-identifier of the get-objects response collection,
+        ///   defaults to the default value used by the GetObjects command instance</param>
+        public List<KeyValuePair<string, object>> Objects(string outIdentifier = null)
+        {
+            var outObject = this[String.IsNullOrEmpty(outIdentifier) ? 
+                CommandGetObjects.OutIdentifierDefault :
+                outIdentifier
+                ] as JArray;
+
+            if (outObject == null)
+                return null;
+
+            List<KeyValuePair<string, object>> list = new List<KeyValuePair<string, object>>();
+            foreach (var j in outObject)
+            {
+                var first = j.First;
+                var prop = first as JProperty;
+                if (first != null)
+                {
+                    list.Add(new KeyValuePair<string, object>(prop.Name, prop.Value));
+                }
+            }
+
+            return list;
+        }
+
+
+        /// <summary>
+        /// Return the collection of all objects of a type contained in the get-objects command response,
+        /// with the option to override the JsonConverter, drools(java) classname of the objects,
+        /// and the out-identifier of the get-objects response element
+        /// </summary>
+        /// <typeparam name="T">c-sharp class type to retrieve from the get-objects response;
+        /// the class should have a DroolsTypeAttribute or you must specify the className parameter</typeparam>
+        /// <param name="jsonConvert">JsonConverter to use while deserializing the objects</param>
+        /// <param name="className">drools (java) class name of the object, not required if your
+        ///   class has a DroolsTypeAttribute on it to specify the class name</param>
+        /// <param name="outIdentifier">the out-identifier of the get-objects response collection,
+        ///   defaults to the default value used by the GetObjects command instance</param>
+        /// <returns>List of objects of the specified type</returns>
+        public List<T> ObjectsOfType<T>(JsonConverter jsonConvert, string className = null, string outIdentifier = null)
+        {
+            // if no class name given, see if there is a DroolsType attribute to pull it from
+            if (String.IsNullOrEmpty(className))
+            {
+                className = typeof(T).GetAttributeValue<DroolsTypeAttribute, string> ( a => a.TypeName );
+            }
+
+            if (String.IsNullOrEmpty(className))
+                throw new InvalidOperationException("Unable to determine Drools type name for object type");
+
+            var list = Objects(outIdentifier).FindAll(a => a.Key.Equals(className));
+
+            List<T> results = new List<T>();
+            foreach (var j in list)
+            {
+                var obj = JsonConvert.DeserializeObject<T>(j.Value.ToString(), jsonConvert);
+                if (obj != null)
+                    results.Add(obj);
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Return the collection of all objects of a type contained in the get-objects command response,
+        /// with the option to override the drools(java) classname of the objects,
+        /// and the out-identifier of the get-objects response element
+        /// </summary>
+        /// <typeparam name="T">c-sharp class type to retrieve from the get-objects response;
+        /// the class should have a DroolsTypeAttribute or you must specify the className parameter</typeparam>
+        /// <param name="className">drools (java) class name of the object, not required if your
+        ///   class has a DroolsTypeAttribute on it to specify the class name</param>
+        /// <param name="outIdentifier">the out-identifier of the get-objects response collection,
+        ///   defaults to the default value used by the GetObjects command instance</param>
+        /// <returns>List of objects of the specified type</returns>
+        public List<T> ObjectsOfType<T>(string className = null, string outIdentifier = null)
+        {
+            return ObjectsOfType<T>(new UnixTimestampConverter(), className, outIdentifier);
+        }
+
+        /// <summary>
+        /// return the result instance of a query command
+        /// </summary>
+        /// <param name="outIdentifier">out-identifier of the query results if a non-default value 
+        /// was used in the command</param>
+        public FlatQueryResults QueryResult(string outIdentifier = null)
+        {
+            var qryResult = this[String.IsNullOrEmpty(outIdentifier) ?
+                CommandQuery.OutIdentifierDefault : outIdentifier] as JObject;
+
+            if (qryResult == null)
+                return null;
+
+            return FlatQueryResults.FromJson(qryResult);
+        }
+
+
     }
 }

--- a/KieServerAdapter/ExecutionResult.cs
+++ b/KieServerAdapter/ExecutionResult.cs
@@ -37,6 +37,26 @@ namespace KieServerAdapter
             List<KeyValuePair<string, object>> list = new List<KeyValuePair<string, object>>();
             foreach (var j in outObject)
             {
+                ExtractObject(j, list);
+            }
+
+            return list;
+        }
+
+        internal void ExtractObject(JToken j, List<KeyValuePair<string, object>> list)
+        {
+            if (!j.HasValues)   // simple type, not an object (i.e. string, bool or some kind of number)
+            {
+                // quote these so the json deserializer can parse and type convert
+                list.Add(new KeyValuePair<string, object>(Enum.GetName(typeof(JTokenType), j.Type), "\"" + j.ToString() + "\""));
+            }
+            else if (j.Type == JTokenType.Array)
+            {
+                // we won't have a type name so use "List" for a list of things
+                list.Add(new KeyValuePair<string, object>("Array", j.ToString()));
+            }
+            else
+            {
                 var first = j.First;
                 var prop = first as JProperty;
                 if (first != null)
@@ -44,10 +64,7 @@ namespace KieServerAdapter
                     list.Add(new KeyValuePair<string, object>(prop.Name, prop.Value));
                 }
             }
-
-            return list;
         }
-
 
         /// <summary>
         /// Return the collection of all objects of a type contained in the get-objects command response,
@@ -55,22 +72,24 @@ namespace KieServerAdapter
         /// and the out-identifier of the get-objects response element
         /// </summary>
         /// <typeparam name="T">c-sharp class type to retrieve from the get-objects response;
-        /// the class should have a DroolsTypeAttribute or you must specify the className parameter</typeparam>
+        /// the class should have a DroolsTypeAttribute or you must specify the className parameter. See remarks.</typeparam>
         /// <param name="jsonConvert">JsonConverter to use while deserializing the objects</param>
         /// <param name="className">drools (java) class name of the object, not required if your
         ///   class has a DroolsTypeAttribute on it to specify the class name</param>
         /// <param name="outIdentifier">the out-identifier of the get-objects response collection,
         ///   defaults to the default value used by the GetObjects command instance</param>
         /// <returns>List of objects of the specified type</returns>
+        /// <remarks>You can retrieve simple types by explicitly specifying the JTokenType name (ex.
+        /// "String", "Integer", etc. with an appropriate T type String, int, etc.)</remarks>
         public List<T> ObjectsOfType<T>(JsonConverter jsonConvert, string className = null, string outIdentifier = null)
         {
             // if no class name given, see if there is a DroolsType attribute to pull it from
-            if (String.IsNullOrEmpty(className))
+            if (className is null)
             {
                 className = typeof(T).GetAttributeValue<DroolsTypeAttribute, string> ( a => a.TypeName );
             }
 
-            if (String.IsNullOrEmpty(className))
+            if (className is null)
                 throw new InvalidOperationException("Unable to determine Drools type name for object type");
 
             var list = Objects(outIdentifier).FindAll(a => a.Key.Equals(className));
@@ -78,9 +97,14 @@ namespace KieServerAdapter
             List<T> results = new List<T>();
             foreach (var j in list)
             {
-                var obj = JsonConvert.DeserializeObject<T>(j.Value.ToString(), jsonConvert);
-                if (obj != null)
-                    results.Add(obj);
+                try
+                {
+                    var obj = JsonConvert.DeserializeObject<T>(j.Value.ToString(), jsonConvert);
+                    if (obj != null)
+                        results.Add(obj);
+                }
+                // eat any exceptions since we really don't know if the list item is one of the objects or not
+                catch(Exception e) { }
             }
 
             return results;

--- a/KieServerAdapter/FlatQueryResults.cs
+++ b/KieServerAdapter/FlatQueryResults.cs
@@ -1,0 +1,150 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+
+namespace KieServerAdapter
+{
+    #region Internal classes used to deserialize the query results JSON structures
+    internal class DroolsMapElement
+    {
+        public string Key;
+        public CommandObject Value;
+    }
+    internal class DroolsMap
+    {
+        [JsonProperty("element")]
+        internal List<DroolsMapElement> Objects;
+    }
+    internal class DroolsListMap
+    {
+        [JsonProperty("element")]
+        internal List<DroolsMap> Maps;
+    }
+
+    internal class DroolsSet
+    {
+        [JsonProperty("element")]
+        internal List<string> Items;
+    }
+    #endregion
+
+    [DroolsType("org.drools.core.runtime.rule.impl.FlatQueryResults")]
+    public class FlatQueryResults
+    {
+        [JsonProperty("idFactHandleMaps")]
+        internal DroolsListMap IdFactHandleMaps;
+
+        [JsonProperty("idResultMaps")]
+        internal DroolsListMap IdResultMaps;
+        
+        [JsonProperty("identifiers")]
+        internal DroolsSet Identifiers;
+
+        /// <summary>
+        /// retrieve the objects collection from the query result maps
+        /// </summary>
+        public List<KeyValuePair<string, object>> Objects
+        {
+            get
+            {
+                var list = new List<KeyValuePair<string, object>>();
+
+                foreach (var map in IdResultMaps.Maps)
+                {
+                    foreach (var obj in map.Objects)
+                    {
+                        list.Add(new KeyValuePair<string, object>(obj.Key, obj.Value));
+                    }
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Return the collection of all objects of a type contained in the query results response,
+        /// with the option to override the JsonConverter, drools(java) classname of the objects,
+        /// and to specify a particular object identifier in the response to select
+        /// </summary>
+        /// <typeparam name="T">c-sharp class type to retrieve from the get-objects response;
+        /// the class should have a DroolsTypeAttribute or you must specify the className parameter</typeparam>
+        /// <param name="jsonConvert">JsonConverter to use while deserializing the objects</param>
+        /// <param name="className">drools (java) class name of the object, not required if your
+        ///   class has a DroolsTypeAttribute on it to specify the class name</param>
+        /// <param name="identifier">the identifier key in the results map if you only want one
+        /// specific instance</param>
+        /// <returns>List of objects of the specified type</returns>
+        public List<T> ObjectsOfType<T>(JsonConverter jsonConvert, string className = null, string identifier = null)
+        {
+            // if no class name given, see if there is a DroolsType attribute to pull it from
+            if (String.IsNullOrEmpty(className))
+            {
+                className = typeof(T).GetAttributeValue<DroolsTypeAttribute, string>(a => a.TypeName);
+            }
+
+            if (String.IsNullOrEmpty(className))
+                throw new InvalidOperationException("Unable to determine Drools type name for object type");
+
+            List<KeyValuePair<string, object>> list = Objects;
+            if (!String.IsNullOrEmpty(identifier))
+            {
+                list = list.FindAll(a => a.Key.Equals(identifier));
+            }
+
+            var items = list.FindAll(a => (a.Value as CommandObject).ObjectNameSpace.Equals(className));
+
+            List<T> results = new List<T>();
+            foreach (var j in items)
+            {
+                var obj = JsonConvert.DeserializeObject<T>((j.Value as CommandObject).CommandItem.ToString(), jsonConvert);
+                if (obj != null)
+                    results.Add(obj);
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Return the collection of all objects of a type contained in the query results response,
+        /// with the option to override the drools(java) classname of the objects,
+        /// and to specify a particular object identifier in the response to select
+        /// </summary>
+        /// <typeparam name="T">c-sharp class type to retrieve from the get-objects response;
+        /// the class should have a DroolsTypeAttribute or you must specify the className parameter</typeparam>
+        /// <param name="className">drools (java) class name of the object, not required if your
+        ///   class has a DroolsTypeAttribute on it to specify the class name</param>
+        /// <param name="identifier">the identifier key in the results map if you only want one
+        /// specific instance</param>
+        /// <returns>List of objects of the specified type</returns>
+        public List<T> ObjectsOfType<T>(string className = null, string identifier = null)
+        {
+            return ObjectsOfType<T>(new UnixTimestampConverter(), className, identifier);
+        }
+
+        /// <summary>
+        /// Factory method that given a JToken of the node containing the query results, 
+        /// deserializes it into a FlatQueryResults instance.
+        /// </summary>
+        public static FlatQueryResults FromJson(JToken json)
+        {
+            var jsonConverter = new UnixTimestampConverter();
+
+            var serializer = new JsonSerializer
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = {  jsonConverter,
+                                new IsoDateTimeConverter() { DateTimeFormat = "yyyy-MM-dd" } 
+                },
+                MissingMemberHandling = MissingMemberHandling.Ignore
+            };
+            var jsonProp = json as JObject;
+            var result = jsonProp.First.First.ToObject<FlatQueryResults>(serializer);
+
+            return result;
+        }
+    }
+}

--- a/KieServerAdapter/GetObjects.cs
+++ b/KieServerAdapter/GetObjects.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace KieServerAdapter
+{
+    public class GetObjects : ICommandContainer
+    {
+        [JsonProperty("get-objects")]
+        public ICommand Command { get; }
+
+        public GetObjects(string outIdentifier = null)
+        {
+            Command = new CommandGetObjects()
+            {
+                OutIdentifier = String.IsNullOrEmpty(outIdentifier) ?
+                    CommandGetObjects.OutIdentifierDefault :
+                    outIdentifier
+            };
+        }
+    }
+}

--- a/KieServerAdapter/ICommand.cs
+++ b/KieServerAdapter/ICommand.cs
@@ -9,7 +9,9 @@
     {
         SetGlobal = 20,
         Insert = 10,
-        FireAllRules = 2,
+        FireAllRules = 4,
+        Query = 3,
+        GetObjects = 2,
         GetGlobal = 1,
         StartProcess = 0
     }

--- a/KieServerAdapter/Insert.cs
+++ b/KieServerAdapter/Insert.cs
@@ -13,5 +13,17 @@ namespace KieServerAdapter
                 CommandObject = new CommandObject(commandObject, objectNameSpace),
                 ReturnObject = returnObject };
         }
+
+        public Insert(object commandObject, string objectNameSpace, string outIdentifier, bool returnObject = true)
+        {
+            Command = new CommandInsert
+            {
+                CommandObject = new CommandObject(commandObject, objectNameSpace),
+                ReturnObject = returnObject
+            };
+            if (!string.IsNullOrEmpty(outIdentifier))
+                ((CommandInsert)Command).OutIdentifier = outIdentifier;
+        }
+
     }
 }

--- a/KieServerAdapter/Insert.cs
+++ b/KieServerAdapter/Insert.cs
@@ -7,9 +7,11 @@ namespace KieServerAdapter
         [JsonProperty("insert")]
         public ICommand Command { get; }
 
-        public Insert(object commandObject, string objectNameSpace)
+        public Insert(object commandObject, string objectNameSpace, bool returnObject = true)
         {
-            Command = new CommandInsert { CommandObject = new CommandObject(commandObject, objectNameSpace) };
+            Command = new CommandInsert { 
+                CommandObject = new CommandObject(commandObject, objectNameSpace),
+                ReturnObject = returnObject };
         }
     }
 }

--- a/KieServerAdapter/JavaLocalDateConverter.cs
+++ b/KieServerAdapter/JavaLocalDateConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KieServerAdapter
+{
+    /// <summary>
+    /// Json converter for the Java LocalDate value returned by Drools
+    /// (an array of 3 integers, year, month and day)
+    /// </summary>
+    public class JavaLocalDateConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(DateTime?) || objectType == typeof(DateTime));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JArray arr = JArray.Load(reader);
+            if (arr.Count != 3)
+                throw new InvalidOperationException("Invalid LocalDate array: year, month and day required.");
+
+            return new DateTime((int) arr[0], (int) arr[1], (int) arr[2]);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var dt = (DateTime) value;
+            writer.WriteRawValue("[" + dt.Year + ", " + dt.Month + ", " + dt.Day + "]");
+        }
+    }
+}

--- a/KieServerAdapter/KieExecuter.cs
+++ b/KieServerAdapter/KieExecuter.cs
@@ -54,11 +54,31 @@ namespace KieServerAdapter
             Commands.Add(new Insert(commandObject, objectNameSpace, returnObject));
         }
 
-        public void Insert(object commandObject, bool returnObject = true)
+        public void Insert(object commandObject, string objectNameSpace, string outIdentifier, bool returnObject = true)
+        {
+            Commands.Add(new Insert(commandObject, objectNameSpace, outIdentifier, returnObject));
+        }
+
+        /// <summary>
+        /// insert an object whose type name will come from a DroolsType attribute on the class 
+        /// of the object being inserted
+        /// </summary>
+        public void InsertType(object commandObject, bool returnObject = true)
         {
             var objectNameSpace = commandObject.GetType().GetAttributeValue<DroolsTypeAttribute, string>(a => a.TypeName);
             Insert(commandObject, objectNameSpace, returnObject);
         }
+
+        /// <summary>
+        /// insert an object whose type name will come from a DroolsType attribute on the class 
+        /// of the object being inserted with an explicit out-identifier
+        /// </summary>
+        public void InsertType(object commandObject, string outIdentifier, bool returnObject = true)
+        {
+            var objectNameSpace = commandObject.GetType().GetAttributeValue<DroolsTypeAttribute, string>(a => a.TypeName);
+            Insert(commandObject, objectNameSpace, outIdentifier, returnObject);
+        }
+
 
         public void SetGlobal(string identifier, object commandObject, string objectNameSpace)
         {
@@ -207,4 +227,5 @@ namespace KieServerAdapter
             }
         }
     }
+
 }

--- a/KieServerAdapter/KieServerAdapter.csproj
+++ b/KieServerAdapter/KieServerAdapter.csproj
@@ -31,14 +31,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -50,12 +49,18 @@
   <ItemGroup>
     <Compile Include="CommandFireAllRules.cs" />
     <Compile Include="CommandGetGlobal.cs" />
+    <Compile Include="CommandGetObjects.cs" />
+    <Compile Include="CommandQuery.cs" />
     <Compile Include="CommandSetGlobal.cs" />
+    <Compile Include="DroolsTypeAttribute.cs" />
     <Compile Include="ExecutionResult.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="FireAllRules.cs" />
+    <Compile Include="FlatQueryResults.cs" />
     <Compile Include="FriendlyExecutionResponse.cs" />
+    <Compile Include="Query.cs" />
     <Compile Include="GetGlobal.cs" />
+    <Compile Include="GetObjects.cs" />
     <Compile Include="ICommandObject.cs" />
     <Compile Include="ICommandOutIdentifier.cs" />
     <Compile Include="ICommand.cs" />
@@ -71,6 +76,7 @@
     <Compile Include="SetGlobal.cs" />
     <Compile Include="StartProcess.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="JavaLocalDateConverter.cs" />
     <Compile Include="UnixTimestampConverter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/KieServerAdapter/KieServerAdapter.csproj
+++ b/KieServerAdapter/KieServerAdapter.csproj
@@ -32,12 +32,12 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/KieServerAdapter/Properties/AssemblyInfo.cs
+++ b/KieServerAdapter/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/KieServerAdapter/Query.cs
+++ b/KieServerAdapter/Query.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace KieServerAdapter
+{
+    public class Query : ICommandContainer
+    {
+        [JsonProperty("query")]
+        public ICommand Command { get; }
+
+        public Query(string identifier, string outIdentifier = null, IEnumerable<object> arguments = null)
+        {
+            Command = new CommandQuery
+            {
+                Name = identifier,
+                Arguments = arguments,
+                OutIdentifier = String.IsNullOrEmpty(outIdentifier) ?
+                CommandQuery.OutIdentifierDefault :
+                outIdentifier
+            };
+        }
+    }
+}

--- a/KieServerAdapter/app.config
+++ b/KieServerAdapter/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/KieServerAdapter/packages.config
+++ b/KieServerAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="NuGet.CommandLine" version="4.1.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 KieServerAdapter is a restful client for Drools KieServer. You can easily call rules with your .Net project. 
 These are the covered functions, documented here (https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#runtime-commands-samples-ref_kie-apis).
 
-  - [SetGlobalCommand]
-  - [InsertObjectCommand]
-  - [StartProcessCommand]
-  - [FireAllRulesCommand]
-  - [GetGlobalCommand]
-  - [GetObjectsCommand]
-  - [QueryCommand]
+  - `SetGlobalCommand`
+  - `InsertObjectCommand`
+  - `StartProcessCommand`
+  - `FireAllRulesCommand`
+  - `GetGlobalCommand`
+  - `GetObjectsCommand`
+  - `QueryCommand`
 
 Drools also open source but it is in Java Stack and Kie Server is talented execution server and has restful feautures please see the full documantation in  https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_kie.ksrestapi
 
@@ -56,16 +56,16 @@ Please see the KieServerAdapter.Test project for more detailed examples.
 
 ### Getting fact data to and from KIE server
 There a several different options retrieving results from Drools via the KIE server:
--- Insert fact models, have Drools modify the inserted facts, and retrieve the facts by their out-identifier after the rules fire.  That's how the example above works.
--- Insert fact models, have Drools create new facts from the rules, then use the GetObjects command to pull down _all_ of the final facts in memory.
--- Insert fact models, have Drools create new facts from the rules, then use Query command with DRL queries to retrieve specific objects from Drools memory.  This option makes sense if your rules are creating a lot of memory objects.
+* Insert fact models, have Drools modify the inserted facts, and retrieve the facts by their out-identifier after the rules fire.  That's how the example above works.
+* Insert fact models, have Drools create new facts from the rules, then use the GetObjects command to pull down _all_ of the final facts in Drools memory.
+* Insert fact models, have Drools create new facts from the rules, then use Query command with DRL queries to retrieve specific objects from Drools memory.  This option makes sense if your rules are creating a lot of memory objects.
 
 You could be using several of these options at once, even in the same batch command list.  But notice only the last two
-options let you retrieve new facts created by the rules flow (either use GetObjects to get them all or Query to get
-specific new facts.)
+options let you retrieve new facts created by the rules flow (either use GetObjects to get them all or Query commands to get
+one or more specific new facts.)
 
 If you use GetObjects or Query, you should add the DroolsTypeAttribute to your data model classes to make using
-methods like ObjectsByType<T> easier to use:
+methods like `ObjectsByType<T>` easier to use:
 
 ```csharp
 [DroolsType("com.mycompany.mymodule.AsOfDate")]
@@ -75,16 +75,16 @@ public class AsOfDate
     public DateTime Date { get; set; }
 }
 
-// later in the code, firing the rules and retrieving all objects
+// ...later in the code, firing the rules and retrieving all objects
 executer.FireAllRules();
 executer.GetObjects();
-var response = await executer.ExecuteAsync("MyDeployment");
+var response = await executer.ExecuteAsync("MyContainer");
 var asOfDates = response.Result.ExecutionResults.ObjectsOfType<AsOfDate>();
 
-// or alternately query for a specific object
+// or alternately query for a specific object type using a Query
 executer.FireAllRules();
 executer.Query("GetAsOfDateInstace", "resultAsOf");
-var response = await executer.ExecuteAsync("MyDeployment");
+var response = await executer.ExecuteAsync("MyContainer");
 var qryResult = response.Result.ExecutionResults.QueryResult("resultAsOf");
 var asOfDates = qryResult.ObjectsOfType<AsOfDate>();
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ You could be using several of these options at once, even in the same batch comm
 options let you retrieve new facts created by the rules flow (either use GetObjects to get them all or Query commands to get
 one or more specific new facts.)
 
-If you use GetObjects or Query, you should add the `DroolsTypeAttribute` to your data model classes to make using
+A `DroolsTypeAttribute` attribute can be used to identify the Java class name Drools
+will return for a given C# object model.  Use the `InsertType` methods instead of the `Insert` 
+methods to insert objects tagged with this attribute, which also allow you to set an explicit out-identifier to make later retrieval by out-identifier from the results easier.
+
+Particularly if you use GetObjects or Query command, you should definitely add the `DroolsTypeAttribute` to your data model classes and use the `InsertType` methods to make using
 methods like `ObjectsOfType<T>` easier to use:
 
 ```csharp
@@ -81,10 +85,22 @@ executer.GetObjects();
 var response = await executer.ExecuteAsync("MyContainer");
 var asOfDates = response.Result.ExecutionResults.ObjectsOfType<AsOfDate>();
 
-// or alternately query for a specific object type using a Query
+// or alternately query for a specific object type result using a Query
 executer.FireAllRules();
-executer.Query("GetAsOfDateInstace", "resultAsOf");
+executer.Query("GetAsOfDateInstance", "resultAsOf");
 var response = await executer.ExecuteAsync("MyContainer");
 var qryResult = response.Result.ExecutionResults.QueryResult("resultAsOf");
 var asOfDates = qryResult.ObjectsOfType<AsOfDate>();
+```
+
+Simple types can also be inserted and retrieved from results, and arrays created 
+by Drools (usally by creating an ArrayList instance) can be retrieved as well:
+```csharp
+executer.Insert("my favorite string", "java.lang.String", true);
+executer.Insert(4593, "java.lang.Integer", true);
+
+//... and later looking at the response
+var strs = response.Result.ExecutionResults.ObjectsOfType<String>("String");           
+var ints = response.Result.ExecutionResults.ObjectsOfType<int>("Integer");
+var lists = response.Result.ExecutionResults.ObjectsOfType<List<string>>("Array");
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # .Net KieServerAdapter for ![Logo](Files/DroolsLogo210px.png)
 
-KieServerAdapter is a restful client for Drools KieServer. You can easily call rules with your .Net project. These are the covered functions.
+KieServerAdapter is a restful client for Drools KieServer. You can easily call rules with your .Net project. 
+These are the covered functions, documented here (https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#runtime-commands-samples-ref_kie-apis).
 
-  - [SetGlobalCommand](https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_setglobalcommand)
-  - [InsertObjectCommand](https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_insertobjectcommand)
-  - [StartProcessCommand](https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_startprocesscommand)
-  - [FireAllRulesCommand](https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_fireallrulescommand)
-  - [GetGlobalCommand](https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_getglobalcommand)
+  - [SetGlobalCommand]
+  - [InsertObjectCommand]
+  - [StartProcessCommand]
+  - [FireAllRulesCommand]
+  - [GetGlobalCommand]
+  - [GetObjectsCommand]
+  - [QueryCommand]
 
 Drools also open source but it is in Java Stack and Kie Server is talented execution server and has restful feautures please see the full documantation in  https://docs.jboss.org/drools/release/latest/drools-docs/html_single/#_kie.ksrestapi
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Please see the KieServerAdapter.Test project for more detailed examples.
 There a several different options retrieving results from Drools via the KIE server:
 * Insert fact models, have Drools modify the inserted facts, and retrieve the facts by their out-identifier after the rules fire.  That's how the example above works.
 * Insert fact models, have Drools create new facts from the rules, then use the GetObjects command to pull down _all_ of the final facts in Drools memory.
-* Insert fact models, have Drools create new facts from the rules, then use Query command with DRL queries to retrieve specific objects from Drools memory.  This option makes sense if your rules are creating a lot of memory objects.
+* Insert fact models, have Drools create new facts from the rules, then use the Query command with DRL queries to retrieve specific objects from Drools memory.  This option makes sense if your rules are creating a lot of memory objects.
 
 You could be using several of these options at once, even in the same batch command list.  But notice only the last two
 options let you retrieve new facts created by the rules flow (either use GetObjects to get them all or Query commands to get
 one or more specific new facts.)
 
-If you use GetObjects or Query, you should add the DroolsTypeAttribute to your data model classes to make using
-methods like `ObjectsByType<T>` easier to use:
+If you use GetObjects or Query, you should add the `DroolsTypeAttribute` to your data model classes to make using
+methods like `ObjectsOfType<T>` easier to use:
 
 ```csharp
 [DroolsType("com.mycompany.mymodule.AsOfDate")]


### PR DESCRIPTION
- Updated project references for Microsoft.AspNet.WebApi.Client and Newtonsoft.Json to current release.
- Added support for GetObjects and Query, including for simple types like String and Integer as well.
- New DroolsTypeAttribute to explicitly tie the Java class name in Drools to the C# object, and associated new methods InsertType for inserting objects into the request that are tagged with this attribute. This attribute is especially helpful for GetObjects and Query results via the added ObjectsOfType methods which can use the attribute value to determine which items in the response match up with the Type T you are trying to retrieve.
